### PR TITLE
fix in browser JavaScript warning about createRoot importing from react-dom

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import './index.css';
 import App from './App';
 
@@ -12,7 +12,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 
 const msalInstance = new PublicClientApplication(msalConfig);
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
 
 /**
  * We recommend wrapping most or all of your components in the MsalProvider component. It's best to render the MsalProvider as close to the root as possible.


### PR DESCRIPTION
```sh
Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".
```