### PR TITLE
Add GitHub Actions workflow for frontend container build

### DIFF
--- a/.github/workflows/frontend-build-and-push-contaier-to-ghcr.yml
+++ b/.github/workflows/frontend-build-and-push-contaier-to-ghcr.yml
@@ -1,0 +1,27 @@
+name: frontend - build and push container to GHCR
+
+on:
+  push:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:frontend"
+          push: true
+          tags: frontend:latest


### PR DESCRIPTION
WIP goal:
on push to main (that includes changes under `frontend/`) build the frontend container and push it to GHCR with a `latest` tag so that it can be pulled by an Azure App Container

currently:
```
ERROR: failed to build: unauthorized: access token has insufficient scopes
```