### PR TITLE
fix(ci): pass Azure token to "close" step of SWA action

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-desert-073eb0e1e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-desert-073eb0e1e.yml
@@ -62,4 +62,5 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_DESERT_073EB0E1E }}
           action: "close"


### PR DESCRIPTION
This should (I think?) allow the Azure SWA action to clean up after itself, and delete staging environments when PRs are closed.