### PR TITLE
Remove bottom-border style from section headings

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -67,7 +67,6 @@ h5 {
   font-weight: 600;
   margin-bottom: 16px;
   padding-bottom: 8px;
-  border-bottom: 2px solid var(--color-energy-100);
 }
 
 /* List items */


### PR DESCRIPTION
This removes the thin green line under each section heading, which looks weird and is unnecessary since each section is in its own content card anyway.